### PR TITLE
Create Application Architure

### DIFF
--- a/AwesomeMovie.xcodeproj/project.pbxproj
+++ b/AwesomeMovie.xcodeproj/project.pbxproj
@@ -13,6 +13,21 @@
 		310B82592992CD4E00C0B97B /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 310B82572992CD4E00C0B97B /* Main.storyboard */; };
 		310B825B2992CD4F00C0B97B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 310B825A2992CD4F00C0B97B /* Assets.xcassets */; };
 		310B825E2992CD4F00C0B97B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 310B825C2992CD4F00C0B97B /* LaunchScreen.storyboard */; };
+		310B82672992D1AD00C0B97B /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B82662992D1AD00C0B97B /* Coordinator.swift */; };
+		310B82692992D1BB00C0B97B /* ApplicationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B82682992D1BB00C0B97B /* ApplicationCoordinator.swift */; };
+		310B826F2992D4EF00C0B97B /* BaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B826E2992D4EF00C0B97B /* BaseView.swift */; };
+		310B82722992D5CA00C0B97B /* BaseCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B82712992D5CA00C0B97B /* BaseCoordinator.swift */; };
+		310B82752992D63600C0B97B /* RouterFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B82742992D63600C0B97B /* RouterFactory.swift */; };
+		310B82772992D65C00C0B97B /* RouterImp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B82762992D65C00C0B97B /* RouterImp.swift */; };
+		310B82792992F7AF00C0B97B /* AppCoordinatorFactoryOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B82782992F7AF00C0B97B /* AppCoordinatorFactoryOutput.swift */; };
+		310B827B2992FD9400C0B97B /* Presentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B827A2992FD9400C0B97B /* Presentable.swift */; };
+		310B827E299306A800C0B97B /* CoordinatorFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B827D299306A800C0B97B /* CoordinatorFactory.swift */; };
+		310B82802993072B00C0B97B /* CoordinatorFactoryImp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B827F2993072B00C0B97B /* CoordinatorFactoryImp.swift */; };
+		310B82822993076C00C0B97B /* ModuleFactoryImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B82812993076C00C0B97B /* ModuleFactoryImplementation.swift */; };
+		310B8286299308E700C0B97B /* NSObjectExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B8285299308E700C0B97B /* NSObjectExtensions.swift */; };
+		310B8288299308FD00C0B97B /* UIViewControllerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B8287299308FD00C0B97B /* UIViewControllerExtension.swift */; };
+		310B828A2993093500C0B97B /* BundleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B82892993093500C0B97B /* BundleExtensions.swift */; };
+		310B828C299309DC00C0B97B /* DeepLinkOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310B828B299309DC00C0B97B /* DeepLinkOption.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -24,6 +39,21 @@
 		310B825A2992CD4F00C0B97B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		310B825D2992CD4F00C0B97B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		310B825F2992CD4F00C0B97B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		310B82662992D1AD00C0B97B /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
+		310B82682992D1BB00C0B97B /* ApplicationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationCoordinator.swift; sourceTree = "<group>"; };
+		310B826E2992D4EF00C0B97B /* BaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseView.swift; sourceTree = "<group>"; };
+		310B82712992D5CA00C0B97B /* BaseCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCoordinator.swift; sourceTree = "<group>"; };
+		310B82742992D63600C0B97B /* RouterFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterFactory.swift; sourceTree = "<group>"; };
+		310B82762992D65C00C0B97B /* RouterImp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouterImp.swift; sourceTree = "<group>"; };
+		310B82782992F7AF00C0B97B /* AppCoordinatorFactoryOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinatorFactoryOutput.swift; sourceTree = "<group>"; };
+		310B827A2992FD9400C0B97B /* Presentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presentable.swift; sourceTree = "<group>"; };
+		310B827D299306A800C0B97B /* CoordinatorFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorFactory.swift; sourceTree = "<group>"; };
+		310B827F2993072B00C0B97B /* CoordinatorFactoryImp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoordinatorFactoryImp.swift; sourceTree = "<group>"; };
+		310B82812993076C00C0B97B /* ModuleFactoryImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleFactoryImplementation.swift; sourceTree = "<group>"; };
+		310B8285299308E700C0B97B /* NSObjectExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSObjectExtensions.swift; sourceTree = "<group>"; };
+		310B8287299308FD00C0B97B /* UIViewControllerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewControllerExtension.swift; sourceTree = "<group>"; };
+		310B82892993093500C0B97B /* BundleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtensions.swift; sourceTree = "<group>"; };
+		310B828B299309DC00C0B97B /* DeepLinkOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkOption.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,15 +86,110 @@
 		310B82502992CD4E00C0B97B /* AwesomeMovie */ = {
 			isa = PBXGroup;
 			children = (
-				310B82512992CD4E00C0B97B /* AppDelegate.swift */,
-				310B82532992CD4E00C0B97B /* SceneDelegate.swift */,
-				310B82552992CD4E00C0B97B /* ViewController.swift */,
-				310B82572992CD4E00C0B97B /* Main.storyboard */,
+				310B82652992D14000C0B97B /* Scenes */,
 				310B825A2992CD4F00C0B97B /* Assets.xcassets */,
 				310B825C2992CD4F00C0B97B /* LaunchScreen.storyboard */,
 				310B825F2992CD4F00C0B97B /* Info.plist */,
 			);
 			path = AwesomeMovie;
+			sourceTree = "<group>";
+		};
+		310B82652992D14000C0B97B /* Scenes */ = {
+			isa = PBXGroup;
+			children = (
+				310B82832993081200C0B97B /* Application */,
+				310B82702992D5B300C0B97B /* Coordinators */,
+				310B826C2992D33500C0B97B /* Favourite */,
+				310B826B2992D33000C0B97B /* Home */,
+				310B826A2992D21500C0B97B /* MainTabView */,
+			);
+			path = Scenes;
+			sourceTree = "<group>";
+		};
+		310B826A2992D21500C0B97B /* MainTabView */ = {
+			isa = PBXGroup;
+			children = (
+				310B82572992CD4E00C0B97B /* Main.storyboard */,
+			);
+			path = MainTabView;
+			sourceTree = "<group>";
+		};
+		310B826B2992D33000C0B97B /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				310B82552992CD4E00C0B97B /* ViewController.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
+		310B826C2992D33500C0B97B /* Favourite */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Favourite;
+			sourceTree = "<group>";
+		};
+		310B826D2992D4CE00C0B97B /* CoordinatorProtocols */ = {
+			isa = PBXGroup;
+			children = (
+				310B82662992D1AD00C0B97B /* Coordinator.swift */,
+				310B826E2992D4EF00C0B97B /* BaseView.swift */,
+				310B827A2992FD9400C0B97B /* Presentable.swift */,
+				310B828B299309DC00C0B97B /* DeepLinkOption.swift */,
+			);
+			path = CoordinatorProtocols;
+			sourceTree = "<group>";
+		};
+		310B82702992D5B300C0B97B /* Coordinators */ = {
+			isa = PBXGroup;
+			children = (
+				310B8284299308BA00C0B97B /* CoordinatorExtensions */,
+				310B827C2993069800C0B97B /* CoordinatorsFactory */,
+				310B82732992D62600C0B97B /* Router */,
+				310B826D2992D4CE00C0B97B /* CoordinatorProtocols */,
+				310B82712992D5CA00C0B97B /* BaseCoordinator.swift */,
+			);
+			path = Coordinators;
+			sourceTree = "<group>";
+		};
+		310B82732992D62600C0B97B /* Router */ = {
+			isa = PBXGroup;
+			children = (
+				310B82742992D63600C0B97B /* RouterFactory.swift */,
+				310B82762992D65C00C0B97B /* RouterImp.swift */,
+			);
+			path = Router;
+			sourceTree = "<group>";
+		};
+		310B827C2993069800C0B97B /* CoordinatorsFactory */ = {
+			isa = PBXGroup;
+			children = (
+				310B827D299306A800C0B97B /* CoordinatorFactory.swift */,
+				310B827F2993072B00C0B97B /* CoordinatorFactoryImp.swift */,
+				310B82812993076C00C0B97B /* ModuleFactoryImplementation.swift */,
+			);
+			path = CoordinatorsFactory;
+			sourceTree = "<group>";
+		};
+		310B82832993081200C0B97B /* Application */ = {
+			isa = PBXGroup;
+			children = (
+				310B82512992CD4E00C0B97B /* AppDelegate.swift */,
+				310B82532992CD4E00C0B97B /* SceneDelegate.swift */,
+				310B82682992D1BB00C0B97B /* ApplicationCoordinator.swift */,
+				310B82782992F7AF00C0B97B /* AppCoordinatorFactoryOutput.swift */,
+			);
+			path = Application;
+			sourceTree = "<group>";
+		};
+		310B8284299308BA00C0B97B /* CoordinatorExtensions */ = {
+			isa = PBXGroup;
+			children = (
+				310B8285299308E700C0B97B /* NSObjectExtensions.swift */,
+				310B8287299308FD00C0B97B /* UIViewControllerExtension.swift */,
+				310B82892993093500C0B97B /* BundleExtensions.swift */,
+			);
+			path = CoordinatorExtensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -138,9 +263,24 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				310B82672992D1AD00C0B97B /* Coordinator.swift in Sources */,
+				310B82802993072B00C0B97B /* CoordinatorFactoryImp.swift in Sources */,
 				310B82562992CD4E00C0B97B /* ViewController.swift in Sources */,
+				310B82792992F7AF00C0B97B /* AppCoordinatorFactoryOutput.swift in Sources */,
+				310B8288299308FD00C0B97B /* UIViewControllerExtension.swift in Sources */,
+				310B827E299306A800C0B97B /* CoordinatorFactory.swift in Sources */,
+				310B82692992D1BB00C0B97B /* ApplicationCoordinator.swift in Sources */,
+				310B826F2992D4EF00C0B97B /* BaseView.swift in Sources */,
+				310B828A2993093500C0B97B /* BundleExtensions.swift in Sources */,
+				310B82722992D5CA00C0B97B /* BaseCoordinator.swift in Sources */,
+				310B828C299309DC00C0B97B /* DeepLinkOption.swift in Sources */,
 				310B82522992CD4E00C0B97B /* AppDelegate.swift in Sources */,
+				310B82772992D65C00C0B97B /* RouterImp.swift in Sources */,
+				310B82822993076C00C0B97B /* ModuleFactoryImplementation.swift in Sources */,
+				310B8286299308E700C0B97B /* NSObjectExtensions.swift in Sources */,
 				310B82542992CD4E00C0B97B /* SceneDelegate.swift in Sources */,
+				310B827B2992FD9400C0B97B /* Presentable.swift in Sources */,
+				310B82752992D63600C0B97B /* RouterFactory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AwesomeMovie/Scenes/Application/AppCoordinatorFactoryOutput.swift
+++ b/AwesomeMovie/Scenes/Application/AppCoordinatorFactoryOutput.swift
@@ -1,0 +1,12 @@
+//
+//  CoordinatorFactoryOutPut.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 07/02/2023.
+//
+
+import Foundation
+
+protocol AppCoordinatorFactoryOutput{
+    var finishFlow: (() -> Void)? { get set }
+}

--- a/AwesomeMovie/Scenes/Application/AppDelegate.swift
+++ b/AwesomeMovie/Scenes/Application/AppDelegate.swift
@@ -1,0 +1,53 @@
+//
+//  AppDelegate.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 07/02/2023.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    
+    var window: UIWindow?
+    var rootController: UINavigationController {
+        window = UIWindow(frame: UIScreen.main.bounds)
+        window?.rootViewController = UINavigationController()
+        window?.makeKeyAndVisible()
+        return self.window?.rootViewController as? UINavigationController ?? UINavigationController()
+    }
+    
+    lazy var applicationCoordinator: Coordinator = self.makeCoordinator()
+
+    private func makeCoordinator() -> Coordinator {
+        return ApplicationCoordinator(
+          router: RouterImp(rootController: self.rootController),
+          coordinatorFactory: CoordinatorFactoryImp(),
+          moduleFactory: ModuleFactoryImplementation()
+        )
+    }
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        applicationCoordinator.start()
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/AwesomeMovie/Scenes/Application/ApplicationCoordinator.swift
+++ b/AwesomeMovie/Scenes/Application/ApplicationCoordinator.swift
@@ -1,0 +1,29 @@
+//
+//  AppCoordinator.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 07/02/2023.
+//
+
+import Foundation
+
+final class ApplicationCoordinator: BaseCoordinator,AppCoordinatorFactoryOutput {
+    var finishFlow: (() -> Void)?
+    
+    private let coordinatorFactory: CoordinatorFactory
+    private let router: RouterFactory
+    private let moduleFactory: ModuleFactoryImplementation
+    
+    init(router: RouterFactory,coordinatorFactory: CoordinatorFactory, moduleFactory: ModuleFactoryImplementation) {
+        self.router = router
+        self.coordinatorFactory = coordinatorFactory
+        self.moduleFactory = moduleFactory
+    }
+    
+    override func start(with option: DeepLinkOption?) {
+        runMainFlow()
+    }
+    private func runMainFlow() {
+        
+    }
+}

--- a/AwesomeMovie/Scenes/Application/SceneDelegate.swift
+++ b/AwesomeMovie/Scenes/Application/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 07/02/2023.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/AwesomeMovie/Scenes/Coordinators/BaseCoordinator.swift
+++ b/AwesomeMovie/Scenes/Coordinators/BaseCoordinator.swift
@@ -1,0 +1,38 @@
+//
+//  BaseCoordinator.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 07/02/2023.
+//
+
+import Foundation
+
+class BaseCoordinator: Coordinator{
+    
+    
+    //UINavigationController property handling by router in BaseCoordinator subclass (like app coordinator)
+    
+    // property to store all child coordinator
+    var childCoordinators: [Coordinator] = []
+    func start() {
+        start(with: nil)
+    }
+    func start(with option: DeepLinkOption?) {}
+    func addDependecny(_ coordinator: Coordinator){
+        guard !childCoordinators.contains(where: {$0 === coordinator}) else{ return}
+        childCoordinators.append(coordinator)
+    }
+    
+    func removeDependency(_ coordinator: Coordinator?){
+        guard childCoordinators.isEmpty == false, let coordinator = coordinator else {return}
+        
+        if let coordinator = coordinator as? BaseCoordinator, !coordinator.childCoordinators.isEmpty{
+            coordinator.childCoordinators.filter({$0 !== coordinator}).forEach({coordinator.removeDependency($0)})
+        }
+        for (index, element) in childCoordinators.enumerated() where element === coordinator {
+            childCoordinators.remove(at: index)
+            break
+        }
+    }
+    
+}

--- a/AwesomeMovie/Scenes/Coordinators/CoordinatorExtensions/BundleExtensions.swift
+++ b/AwesomeMovie/Scenes/Coordinators/CoordinatorExtensions/BundleExtensions.swift
@@ -1,0 +1,18 @@
+//
+//  BundleExtensions.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 08/02/2023.
+//
+
+import Foundation
+import UIKit
+extension Bundle {
+    static func loadView<T>(fromNib name: String, withType type: T.Type) -> T {
+        if let view = Bundle.main.loadNibNamed(name, owner: nil, options: nil)?.first as? T {
+            return view
+        }
+        fatalError("Could not load view with type " + String(describing: type))
+    }
+}
+

--- a/AwesomeMovie/Scenes/Coordinators/CoordinatorExtensions/NSObjectExtensions.swift
+++ b/AwesomeMovie/Scenes/Coordinators/CoordinatorExtensions/NSObjectExtensions.swift
@@ -1,0 +1,15 @@
+//
+//  NSObjectExtensions.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 08/02/2023.
+//
+
+import Foundation
+
+extension NSObject {
+  
+  class var nameOfClass: String {
+    return NSStringFromClass(self).components(separatedBy: ".").last!
+  }
+}

--- a/AwesomeMovie/Scenes/Coordinators/CoordinatorExtensions/UIViewControllerExtension.swift
+++ b/AwesomeMovie/Scenes/Coordinators/CoordinatorExtensions/UIViewControllerExtension.swift
@@ -1,0 +1,42 @@
+//
+//  UIViewControllerExtension.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 08/02/2023.
+//
+
+import Foundation
+import UIKit
+
+extension UIViewController {
+    
+    private class func instantiateControllerInStoryboard<T: UIViewController>(_ storyboard: UIStoryboard, identifier: String) -> T {
+        return storyboard.instantiateViewController(withIdentifier: identifier) as! T
+    }
+    private class func instantiateFromNib<T: UIViewController>() -> T {
+        return T.init(nibName: String(describing: T.self), bundle: nil)
+    }
+
+    
+    
+    class func controllerInStoryboard(_ storyboard: UIStoryboard, identifier: String) -> Self {
+        return instantiateControllerInStoryboard(storyboard, identifier: identifier)
+    }
+    
+    class func controllerInStoryboard(_ storyboard: UIStoryboard) -> Self {
+        return controllerInStoryboard(storyboard, identifier: nameOfClass)
+    }
+    
+    class func controllerFromStoryboard(_ storyboard: Storyboards) -> Self {
+        return controllerInStoryboard(UIStoryboard(name: storyboard.rawValue, bundle: nil), identifier: nameOfClass)
+    }
+    class func loadFromNib() -> Self {
+        return instantiateFromNib()
+    }
+    
+}
+
+
+enum Storyboards: String {
+    case main = "Main"
+}

--- a/AwesomeMovie/Scenes/Coordinators/CoordinatorProtocols/BaseView.swift
+++ b/AwesomeMovie/Scenes/Coordinators/CoordinatorProtocols/BaseView.swift
@@ -1,0 +1,12 @@
+//
+//  BaseView.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 07/02/2023.
+//
+
+import Foundation
+
+protocol BaseView{
+    var finishFlow: (() -> Void)? {get set}
+}

--- a/AwesomeMovie/Scenes/Coordinators/CoordinatorProtocols/Coordinator.swift
+++ b/AwesomeMovie/Scenes/Coordinators/CoordinatorProtocols/Coordinator.swift
@@ -1,0 +1,13 @@
+//
+//  Coordinator.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 07/02/2023.
+//
+
+import Foundation
+
+protocol Coordinator: AnyObject{
+    func start()
+    func start(with option: DeepLinkOption?)
+}

--- a/AwesomeMovie/Scenes/Coordinators/CoordinatorProtocols/DeepLinkOption.swift
+++ b/AwesomeMovie/Scenes/Coordinators/CoordinatorProtocols/DeepLinkOption.swift
@@ -1,0 +1,10 @@
+//
+//  DeepLinkOptions.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 08/02/2023.
+//
+
+import Foundation
+
+enum DeepLinkOption {}

--- a/AwesomeMovie/Scenes/Coordinators/CoordinatorProtocols/Presentable.swift
+++ b/AwesomeMovie/Scenes/Coordinators/CoordinatorProtocols/Presentable.swift
@@ -1,0 +1,22 @@
+//
+//  Presentable.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 07/02/2023.
+//
+/**
+ It is made for flexibility and as well as abstraction. We can create a module as complicated as we want, but it is necessary to extract UIViewController for the router’s usage. It does not matter which approach the module will use for getting this controller.
+
+ */
+import Foundation
+import UIKit
+
+protocol Presentable{
+    func toPresent() -> UIViewController?
+}
+
+extension UIViewController: Presentable{
+    func toPresent() -> UIViewController? {
+        return self
+    }
+}

--- a/AwesomeMovie/Scenes/Coordinators/CoordinatorsFactory/CoordinatorFactory.swift
+++ b/AwesomeMovie/Scenes/Coordinators/CoordinatorsFactory/CoordinatorFactory.swift
@@ -1,0 +1,11 @@
+//
+//  CoordinatorFactory.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 08/02/2023.
+//
+
+import Foundation
+
+protocol CoordinatorFactory {
+}

--- a/AwesomeMovie/Scenes/Coordinators/CoordinatorsFactory/CoordinatorFactoryImp.swift
+++ b/AwesomeMovie/Scenes/Coordinators/CoordinatorsFactory/CoordinatorFactoryImp.swift
@@ -1,0 +1,12 @@
+//
+//  CoordinatorFactoryImp.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 08/02/2023.
+//
+
+import Foundation
+
+final class CoordinatorFactoryImp: CoordinatorFactory {
+    
+}

--- a/AwesomeMovie/Scenes/Coordinators/CoordinatorsFactory/ModuleFactoryImplementation.swift
+++ b/AwesomeMovie/Scenes/Coordinators/CoordinatorsFactory/ModuleFactoryImplementation.swift
@@ -1,0 +1,11 @@
+//
+//  ModuleFactoryImplementation.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 08/02/2023.
+//
+
+import Foundation
+final class ModuleFactoryImplementation {
+    
+}

--- a/AwesomeMovie/Scenes/Coordinators/Router/RouterFactory.swift
+++ b/AwesomeMovie/Scenes/Coordinators/Router/RouterFactory.swift
@@ -1,0 +1,30 @@
+//
+//  RouterFactory.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 07/02/2023.
+//
+/**
+ separated router 1) for single responsiblty to makecoordinator manages flow but it is never responsible for routing.
+ 2) we could either support iPad or add custom screen transitions. Coordinator will never know about it, as it can continue to use the router’s protocol interfaces, like “push”, and not care about new transition animation. The implementation details of push is up to the router. As a result, we can create a composition of router classes for different devices, like iPhone, iPad, TV, or Watch, and have them conform to one general protocol.
+ https://medium.com/blacklane-engineering/coordinators-essential-tutorial-part-i-376c836e9ba7
+ */
+
+import Foundation
+
+protocol RouterFactory: Presentable {
+    func present(_ module: Presentable?)
+    func present(_ module: Presentable?, animated: Bool)
+    func push(_ module: Presentable?)
+    func push(_ module: Presentable?, hideBottomBar: Bool)
+    func push(_ module: Presentable?, animated: Bool)
+    func push(_ module: Presentable?, animated: Bool, completion: (() -> Void)?)
+    func push(_ module: Presentable?, animated: Bool, hideBottomBar: Bool, completion: (() -> Void)?)
+    func popModule()
+    func popModule(animated: Bool)
+    func dismissModule()
+    func dismissModule(animated: Bool, completion: (() -> Void)?)
+    func setRootModule(_ module: Presentable?)
+    func setRootModule(_ module: Presentable?, hideBar: Bool)
+    func popToRootModule(animated: Bool)
+}

--- a/AwesomeMovie/Scenes/Coordinators/Router/RouterImp.swift
+++ b/AwesomeMovie/Scenes/Coordinators/Router/RouterImp.swift
@@ -1,0 +1,104 @@
+//
+//  RouterImp.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 07/02/2023.
+//
+
+import Foundation
+import UIKit
+
+final class RouterImp: NSObject, RouterFactory{
+    
+    private weak var rootController: UINavigationController?
+    private var completions: [UIViewController : () -> Void]
+    
+    init(rootController: UINavigationController) {
+      self.rootController = rootController
+      completions = [:]
+    }
+    
+    func toPresent() -> UIViewController? {
+      return rootController
+    }
+    
+    func present(_ module: Presentable?) {
+      present(module, animated: true)
+    }
+    
+    func present(_ module: Presentable?, animated: Bool) {
+      guard let controller = module?.toPresent() else { return }
+      rootController?.present(controller, animated: animated, completion: nil)
+    }
+    
+    func dismissModule() {
+      dismissModule(animated: true, completion: nil)
+    }
+    
+    func dismissModule(animated: Bool, completion: (() -> Void)?) {
+      rootController?.dismiss(animated: animated, completion: completion)
+    }
+    
+    func push(_ module: Presentable?)  {
+      push(module, animated: true)
+    }
+      
+    func push(_ module: Presentable?, hideBottomBar: Bool)  {
+      push(module, animated: true, hideBottomBar: hideBottomBar, completion: nil)
+    }
+    
+    func push(_ module: Presentable?, animated: Bool)  {
+      push(module, animated: animated, completion: nil)
+    }
+    
+    func push(_ module: Presentable?, animated: Bool, completion: (() -> Void)?) {
+      push(module, animated: animated, hideBottomBar: false, completion: completion)
+    }
+
+    func push(_ module: Presentable?, animated: Bool, hideBottomBar: Bool, completion: (() -> Void)?) {
+      guard
+        let controller = module?.toPresent(),
+        (controller is UINavigationController == false)
+        else { assertionFailure("Deprecated push UINavigationController."); return }
+      
+      if let completion = completion {
+        completions[controller] = completion
+      }
+      controller.hidesBottomBarWhenPushed = hideBottomBar
+      rootController?.pushViewController(controller, animated: animated)
+    }
+    
+    func popModule()  {
+      popModule(animated: true)
+    }
+    
+    func popModule(animated: Bool)  {
+      if let controller = rootController?.popViewController(animated: animated) {
+        runCompletion(for: controller)
+      }
+    }
+    
+    func setRootModule(_ module: Presentable?) {
+      setRootModule(module, hideBar: false)
+    }
+    
+    func setRootModule(_ module: Presentable?, hideBar: Bool) {
+      guard let controller = module?.toPresent() else { return }
+      rootController?.setViewControllers([controller], animated: false)
+      rootController?.isNavigationBarHidden = hideBar
+    }
+    
+    func popToRootModule(animated: Bool) {
+      if let controllers = rootController?.popToRootViewController(animated: animated) {
+        controllers.forEach { controller in
+          runCompletion(for: controller)
+        }
+      }
+    }
+    
+    private func runCompletion(for controller: UIViewController) {
+      guard let completion = completions[controller] else { return }
+      completion()
+      completions.removeValue(forKey: controller)
+    }
+  }

--- a/AwesomeMovie/Scenes/Home/ViewController.swift
+++ b/AwesomeMovie/Scenes/Home/ViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  AwesomeMovie
+//
+//  Created by tayseer anwar on 07/02/2023.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+

--- a/AwesomeMovie/Scenes/MainTabView/Base.lproj/Main.storyboard
+++ b/AwesomeMovie/Scenes/MainTabView/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>


### PR DESCRIPTION
add base coordinator class for all class which handling navigation stack

init app

add init for app by calling app cordinator from appdelegate

App coordinator

handling app coordinator to handel application different init point but for now it handel only one entry point is main flow

views creator extentions

add extention for creating any kind of view , view controller and also for easy get class name

Create BaseView.swift

base view for any view control protocol becouse we will deal with protocol insted of class

Create DeepLinkOption.swift

add deeplink option class to easy able to improve our start point for coordinator by any extra information

Create Presentable.swift

add presentable protocl to deal with protocl insted of class

Create ModuleFactoryImplementation.swift

add base class for implement all modules factory protocols

coordinator creator

add base factory and implemnation for creating coordinatours

routing

add routing factory and implemenation to be responsible about handling  any kind of routing in app

add coordinators protocol

Add protocol need to be confirmed by any coordinator to have all come start point by options passed from other coordinator, from notification or from deepLink or with out

init project

Initial Commit